### PR TITLE
refactor: Battle Phase Manager refactor and tests

### DIFF
--- a/Assets/Scripts/Actions/PlayerActions/AdvancePhase.cs
+++ b/Assets/Scripts/Actions/PlayerActions/AdvancePhase.cs
@@ -9,7 +9,7 @@
 
         public void Execute(Battle battle, Player player)
         {
-            battle.Phase.Advance();
+            battle.BattlePhaseManager.Advance();
         }
     }
 }

--- a/Assets/Scripts/Actions/PlayerActions/AscendFromHand.cs
+++ b/Assets/Scripts/Actions/PlayerActions/AscendFromHand.cs
@@ -11,7 +11,7 @@
 
         public bool CanExecute(Battle battle, Player player)
         {
-            return battle.Phase == BattlePhase.Ascend && (
+            return battle.BattlePhaseManager.Phase == BattlePhase.Ascend && (
                 card.Data.Tier == player.Champion.Card.Data.Tier || 
                 card.Data.Tier == player.Champion.Card.Data.Tier + 1
                 ); 
@@ -21,7 +21,7 @@
         {
             player.Champion.SetCard(card);
             player.Hand.RemoveCard(card);
-            battle.Phase.Advance();
+            battle.BattlePhaseManager.Advance();
         }
     }
 }

--- a/Assets/Scripts/Actions/PlayerActions/DeclareAttack.cs
+++ b/Assets/Scripts/Actions/PlayerActions/DeclareAttack.cs
@@ -11,7 +11,7 @@
         
         public bool CanExecute(Battle battle, Player player)
         {
-            return battle.Phase == BattlePhase.Attack && player == battle.PriorityPlayer;
+            return battle.BattlePhaseManager.Phase == BattlePhase.Attack && player == battle.PriorityPlayer;
         }
 
         public void Execute(Battle battle, Player player)

--- a/Assets/Scripts/Actions/PlayerActions/DefendFromHand.cs
+++ b/Assets/Scripts/Actions/PlayerActions/DefendFromHand.cs
@@ -11,7 +11,7 @@
         
         public bool CanExecute(Battle battle, Player player)
         {
-            return battle.Phase == BattlePhase.Defend && player != battle.AttackingPlayer && card.Data.Tier <= player.Champion.Card.Data.Tier;
+            return battle.BattlePhaseManager.Phase == BattlePhase.Defend && player != battle.AttackingPlayer && card.Data.Tier <= player.Champion.Card.Data.Tier;
         }
 
         public void Execute(Battle battle, Player player)

--- a/Assets/Scripts/Actions/SetPhase.cs
+++ b/Assets/Scripts/Actions/SetPhase.cs
@@ -16,7 +16,7 @@
 
         public void Execute(Battle battle, Player player)
         {
-            battle.Phase.Set(phase);
+            battle.BattlePhaseManager.Set(phase);
         }
     }
 }

--- a/Assets/Scripts/Battle/BattlePhase.cs
+++ b/Assets/Scripts/Battle/BattlePhase.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Linq;
-using JetBrains.Annotations;
-
-namespace CardGame
+﻿namespace CardGame
 {
     public enum BattlePhase
     {
@@ -13,64 +9,5 @@ namespace CardGame
         Defend,
         Damage,
         End
-    }
-
-    public class BattlePhaseManager : IEquatable<BattlePhase>
-    {
-        public static readonly BattlePhase FirstPhase = Enum.GetValues(typeof(BattlePhase)).Cast<BattlePhase>().Min();
-        public static readonly BattlePhase LastPhase = Enum.GetValues(typeof(BattlePhase)).Cast<BattlePhase>().Max();
-        public BattlePhase Value { get; private set; }
-        public event Action OnTurnEnd;
-        public event Action<BattlePhase> OnPhaseEnter;
-
-        public void Set(BattlePhase phase)
-        {
-            if (phase < Value) OnTurnEnd?.Invoke();
-            Value = phase;
-
-            OnPhaseEnter?.Invoke(Value);
-        }
-
-        public void Advance()
-        {
-            // Debug.Log(FirstPhase);
-            // Debug.Log(LastPhase);
-            if (Value == LastPhase)
-            {
-                Value = FirstPhase;
-                OnTurnEnd?.Invoke();
-            }
-            else
-            {
-                Value++;
-            }
-
-            OnPhaseEnter?.Invoke(Value);
-        }
-
-        public bool Equals(BattlePhase other)
-        {
-            return other == Value;
-        }
-
-        public static bool operator ==([NotNull] BattlePhaseManager obj1, BattlePhase obj2)
-        {
-            return obj1.Equals(obj2);
-        }
-
-        public static bool operator !=(BattlePhaseManager obj1, BattlePhase obj2)
-        {
-            return !(obj1 == obj2);
-        }
-
-        public override bool Equals(object obj)
-        {
-            return Equals((BattlePhase) obj);
-        }
-
-        public override int GetHashCode()
-        {
-            return (int) Value;
-        }
     }
 }

--- a/Assets/Scripts/Battle/BattlePhase.cs.meta
+++ b/Assets/Scripts/Battle/BattlePhase.cs.meta
@@ -1,3 +1,3 @@
 ﻿fileFormatVersion: 2
-guid: 3faa870cf58f44068c6ce517e155ee22
-timeCreated: 1670822065
+guid: 2e963d0b233d44cda2b9002d5b7b9773
+timeCreated: 1671164427

--- a/Assets/Scripts/Battle/BattlePhaseManager.cs
+++ b/Assets/Scripts/Battle/BattlePhaseManager.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using System.Linq;
+using JetBrains.Annotations;
+
+namespace CardGame
+{
+    
+
+    public class BattlePhaseManager
+    {
+        public readonly BattlePhase FirstPhase = Enum.GetValues(typeof(BattlePhase)).Cast<BattlePhase>().Min();
+        public readonly BattlePhase LastPhase = Enum.GetValues(typeof(BattlePhase)).Cast<BattlePhase>().Max();
+        public BattlePhase Phase { get; private set; }
+        public event Action OnTurnEnd;
+        public event Action<BattlePhase> OnPhaseExit;
+        public event Action<BattlePhase> OnPhaseEnter;
+
+        public void Set(BattlePhase phase)
+        {
+            OnPhaseExit?.Invoke(Phase);
+            if (phase < Phase) OnTurnEnd?.Invoke();
+            Phase = phase;
+
+            OnPhaseEnter?.Invoke(Phase);
+        }
+
+        public void Advance()
+        {
+            OnPhaseExit?.Invoke(Phase);
+            if (Phase == LastPhase)
+            {
+                Phase = FirstPhase;
+                OnTurnEnd?.Invoke();
+            }
+            else
+            {
+                Phase++;
+            }
+
+            OnPhaseEnter?.Invoke(Phase);
+        }
+    }
+}

--- a/Assets/Scripts/Battle/BattlePhaseManager.cs.meta
+++ b/Assets/Scripts/Battle/BattlePhaseManager.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 3faa870cf58f44068c6ce517e155ee22
+timeCreated: 1670822065

--- a/Assets/Scripts/BattleManager.cs
+++ b/Assets/Scripts/BattleManager.cs
@@ -27,6 +27,8 @@ namespace CardGame
         {
             if (Input.GetKeyDown(KeyCode.F1))
                 Battle.Execute(new AdvancePhase());
+
+            Battle.Tick();
         }
 
         private List<ICard> CreateTestPile()

--- a/Assets/Scripts/Client/BattleOverlayManager.cs
+++ b/Assets/Scripts/Client/BattleOverlayManager.cs
@@ -12,9 +12,9 @@ namespace CardGame
 
         private void Start()
         {
-            battleManager.Battle.Phase.OnPhaseEnter +=
+            battleManager.Battle.BattlePhaseManager.OnPhaseEnter +=
                 phase => UpdatePhaseText(phase, battleManager.Battle.Player1Priority);
-            UpdatePhaseText(battleManager.Battle.Phase.Value, battleManager.Battle.Player1Priority);
+            UpdatePhaseText(battleManager.Battle.BattlePhaseManager.Phase, battleManager.Battle.Player1Priority);
         }
 
         public void NextPhaseButton()

--- a/Assets/Scripts/Client/InputManager.cs
+++ b/Assets/Scripts/Client/InputManager.cs
@@ -21,14 +21,14 @@ namespace CardGame
 
                 CardSlot cardSlot = display.Slot as CardSlot;
                 MultiCardSlot multiCardSlot = display.Slot as MultiCardSlot;
-                if (cardSlot != null && battleManager.Battle.Phase == BattlePhase.Attack && display.Owner == battleManager.Battle.AttackingPlayer)
+                if (cardSlot != null && battleManager.Battle.BattlePhaseManager.Phase == BattlePhase.Attack && display.Owner == battleManager.Battle.AttackingPlayer)
                 {
                     battleManager.Battle.Execute(new DeclareAttack(cardSlot), display.Owner);
-                } else if (multiCardSlot == battleManager.Battle.DefendingPlayer.Hand && battleManager.Battle.Phase == BattlePhase.Defend)
+                } else if (multiCardSlot == battleManager.Battle.DefendingPlayer.Hand && battleManager.Battle.BattlePhaseManager.Phase == BattlePhase.Defend)
                 {
                     battleManager.Battle.Execute(new DefendFromHand(card.Card));
                 } else if (multiCardSlot == battleManager.Battle.AttackingPlayer.Hand &&
-                           battleManager.Battle.Phase == BattlePhase.Ascend)
+                           battleManager.Battle.BattlePhaseManager.Phase == BattlePhase.Ascend)
                 {
                     battleManager.Battle.Execute(new AscendFromHand(card.Card));
                 }

--- a/Assets/Tests/Actions.meta
+++ b/Assets/Tests/Actions.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 8d8e93da5a3b4861bf65d893b0137904
+timeCreated: 1671164384

--- a/Assets/Tests/Battle/BattlePhaseManagerTests.cs
+++ b/Assets/Tests/Battle/BattlePhaseManagerTests.cs
@@ -1,0 +1,77 @@
+﻿using System;
+using System.Linq;
+using CardGame;
+using NUnit.Framework;
+using UnityEngine.UI;
+
+namespace Tests.Battle
+{
+    public class BattlePhaseManagerTests
+    {
+        [Test]
+        public void AdvancePhase()
+        {
+            BattlePhaseManager manager = new BattlePhaseManager();
+            BattlePhase phase = manager.Phase;
+            manager.Advance();
+            Assert.IsTrue(manager.Phase == phase + 1);
+        }
+
+        [Test]
+        public void AdvanceLastPhase()
+        {
+            BattlePhaseManager manager = new BattlePhaseManager();
+            manager.Set(manager.LastPhase);
+            bool phaseEvent = false;
+            manager.OnTurnEnd += () => phaseEvent = true;
+            manager.Advance();
+            Assert.IsTrue(phaseEvent);
+            Assert.AreEqual(manager.Phase, manager.FirstPhase);
+        }
+
+        [Test]
+        public void InitialiseFirstPhase()
+        {
+            BattlePhaseManager manager = new BattlePhaseManager();
+            Assert.AreEqual(manager.Phase, manager.FirstPhase);
+        }
+
+        [Test]
+        public void FirstPhase()
+        {
+            BattlePhase phase = Enum.GetValues(typeof(BattlePhase)).Cast<BattlePhase>().Min();
+            BattlePhaseManager manager = new BattlePhaseManager();
+            Assert.AreEqual(manager.FirstPhase, phase);
+        }
+        
+        [Test]
+        public void LastPhase()
+        {
+            BattlePhase phase = Enum.GetValues(typeof(BattlePhase)).Cast<BattlePhase>().Max();
+            BattlePhaseManager manager = new BattlePhaseManager();
+            Assert.AreEqual(manager.LastPhase, phase);
+        }
+
+        [Test]
+        public void OnPhaseEnter()
+        {
+            BattlePhaseManager manager = new BattlePhaseManager();
+            BattlePhase oldPhase = manager.Phase;
+            BattlePhase phase = manager.LastPhase;
+            manager.OnPhaseEnter += newPhase => phase = newPhase;
+            manager.Advance(); 
+            Assert.AreEqual(phase, oldPhase + 1);
+        }
+
+        [Test]
+        public void OnPhaseExit()
+        {
+            BattlePhaseManager manager = new BattlePhaseManager();
+            BattlePhase oldPhase = manager.Phase;
+            BattlePhase phase = manager.LastPhase;
+            manager.OnPhaseExit += newPhase => phase = newPhase;
+            manager.Advance(); 
+            Assert.AreEqual(phase, oldPhase);
+        }
+    }
+}

--- a/Assets/Tests/Battle/BattlePhaseManagerTests.cs.meta
+++ b/Assets/Tests/Battle/BattlePhaseManagerTests.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 36896346ccb64acaa624675ae75ab172
+timeCreated: 1671164445


### PR DESCRIPTION
Fixes #1 
I've reworked the Battle Phase Manager to not include static items that might change for different battles. 
I also added the distinction between OnPhaseEnter and OnPhaseExit, and made a slight rework in the Battle class to stop infinite loops occurring by only executing one action at a time.
I've also separated the Enum and the Class into separate files to not cause any confusion in the future.
Furthermore, I added tests to ensure that this script continues to work in the future.